### PR TITLE
Quick fix: only load 'cfpropertylist' in darwin

### DIFF
--- a/lib/facter/macaddress_primary.rb
+++ b/lib/facter/macaddress_primary.rb
@@ -1,5 +1,8 @@
 require 'puppet'
-require 'cfpropertylist'
+
+if RUBY_PLATFORM =~ /darwin/
+  require 'cfpropertylist'
+end
 
 Facter.add("macaddress_primary") do
   confine :operatingsystem => :darwin


### PR DESCRIPTION
Fixes the error message 
`"Error loading fact C:/ProgramData/PuppetLabs/puppet/var/lib/facter/macaddress_primary.rb: cannot load such file -- cfpropertylist"`
 on puppet runs. Only load cfpropertylist gem in Darwin; does only make sense on darwin anyway.
